### PR TITLE
Fix crash in AWSXMLRequestSerializer

### DIFF
--- a/AWSCore/Serialization/AWSURLRequestSerialization.m
+++ b/AWSCore/Serialization/AWSURLRequestSerialization.m
@@ -229,6 +229,7 @@
 
     rules = rules[@"members"] ? rules[@"members"] : @{};
 
+    __block NSError *serializerError;
     __block NSString *rawURI = uriSchema;
     [rules enumerateKeysAndObjectsUsingBlock:^(NSString *memberName, id memberRules, BOOL *stop) {
 
@@ -298,7 +299,7 @@
             //If it is "Body" Type and streaming Type, contructBody
             if ([xmlElementName isEqualToString:@"Body"] && [memberRules[@"streaming"] boolValue]) {
                 if ([value isKindOfClass:[NSURL class]]) {
-                    if ([value checkResourceIsReachableAndReturnError:error]) {
+                    if ([value checkResourceIsReachableAndReturnError:&serializerError]) {
                         request.HTTPBodyStream = [NSInputStream inputStreamWithURL:value];
                     }
 
@@ -311,7 +312,8 @@
         }
     }];
 
-    if (*error) {
+    if (serializerError) {
+        *error = serializerError;
         return NO;
     }
 


### PR DESCRIPTION
On certain requests (retries for S3 uploads) in `constructURIandHeadersAndBody:rules:uriSchema:error` if `checkResourceIsReachableAndReturnError:` returns an error it will crash

This is a fix for https://github.com/aws/aws-sdk-ios/issues/95 and can be verified with this [sample project](https://github.com/danielrhammond/AWSSDK-Crash-Sample-Project)