### PR TITLE
[Podfile] Reduce redundency in subspecs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,23 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
-
-workspace 'AWSiOSSDKv2'
-
-xcodeproj 'AWSCore'
-
-link_with 'AWSCoreTests', 'AWSiOSSDKAnalyticsTests'
-pod 'Bolts', '~> 1.1.0'
-pod 'Mantle', '~> 1.4'
-pod 'TMCache', '~> 1.2.1'
-pod 'XMLDictionary', '~> 1.4.0'
-pod 'UICKeyChainStore', '~> 2.0'
-pod 'Reachability', '~> 3.1'
-pod 'GZIP', '~> 1.0.3'
-pod 'FMDB', '~> 2.4'
-
-
-target :AutoScaling do
-  xcodeproj 'AutoScaling'
-  link_with 'AutoScalingTests'
+def default_pods
   pod 'Bolts', '~> 1.1.0'
   pod 'Mantle', '~> 1.4'
   pod 'TMCache', '~> 1.2.1'
@@ -26,134 +7,79 @@ target :AutoScaling do
   pod 'Reachability', '~> 3.1'
   pod 'GZIP', '~> 1.0.3'
   pod 'FMDB', '~> 2.4'
+end
+
+source 'https://github.com/CocoaPods/Specs.git'
+
+workspace 'AWSiOSSDKv2'
+xcodeproj 'AWSCore'
+
+link_with 'AWSCoreTests', 'AWSiOSSDKAnalyticsTests'
+default_pods
+
+target :AutoScaling do
+  xcodeproj 'AutoScaling'
+  link_with 'AutoScalingTests'
+  default_pods
 end
 
 target :CloudWatch do
   xcodeproj 'CloudWatch'
   link_with 'CloudWatchTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :DynamoDB do
   xcodeproj 'DynamoDB'
   link_with 'DynamoDBTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :EC2 do
   xcodeproj 'EC2'
   link_with 'EC2Tests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :ElasticLoadBalancing do
   xcodeproj 'ElasticLoadBalancing'
   link_with 'ElasticLoadBalancingTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :Kinesis do
   xcodeproj 'Kinesis'
   link_with 'KinesisTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :S3 do
   xcodeproj 'S3'
   link_with 'S3Tests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :SES do
   xcodeproj 'SES'
   link_with 'SESTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :SimpleDB do
   xcodeproj 'SimpleDB'
   link_with 'SimpleDBTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :SNS do
   xcodeproj 'SNS'
   link_with 'SNSTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
 
 target :SQS do
   xcodeproj 'SQS'
   link_with 'SQSTests'
-  pod 'Bolts', '~> 1.1.0'
-  pod 'Mantle', '~> 1.4'
-  pod 'TMCache', '~> 1.2.1'
-  pod 'XMLDictionary', '~> 1.4.0'
-  pod 'UICKeyChainStore', '~> 2.0'
-  pod 'Reachability', '~> 3.1'
-  pod 'GZIP', '~> 1.0.3'
-  pod 'FMDB', '~> 2.4'
+  default_pods
 end
+


### PR DESCRIPTION
Uses ruby to reduce the amount of redundancy in your Podfile. If you wanted to go further all of the targets could be generated at runtime too by looping through a list of your targets. Figure this was a nice tradeoff for readability.

Before:

`pod icp podfile Podfile`
```
---
target_definitions:
- name: Pods
  link_with_first_target: true
  user_project_path: AWSCore
  link_with:
  - AWSCoreTests
  - AWSiOSSDKAnalyticsTests
  dependencies:
  - Bolts:
    - "~> 1.1.0"
  - Mantle:
    - "~> 1.4"
  - TMCache:
    - "~> 1.2.1"
  - XMLDictionary:
    - "~> 1.4.0"
  - UICKeyChainStore:
    - "~> 2.0"
  - Reachability:
    - "~> 3.1"
  - GZIP:
    - "~> 1.0.3"
  - FMDB:
    - "~> 2.4"
  children:
  - name: :AutoScaling
    user_project_path: AutoScaling
    link_with:
    - AutoScalingTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :CloudWatch
    user_project_path: CloudWatch
    link_with:
    - CloudWatchTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :DynamoDB
    user_project_path: DynamoDB
    link_with:
    - DynamoDBTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :EC2
    user_project_path: EC2
    link_with:
    - EC2Tests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :ElasticLoadBalancing
    user_project_path: ElasticLoadBalancing
    link_with:
    - ElasticLoadBalancingTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :Kinesis
    user_project_path: Kinesis
    link_with:
    - KinesisTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :S3
    user_project_path: S3
    link_with:
    - S3Tests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SES
    user_project_path: SES
    link_with:
    - SESTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SimpleDB
    user_project_path: SimpleDB
    link_with:
    - SimpleDBTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SNS
    user_project_path: SNS
    link_with:
    - SNSTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SQS
    user_project_path: SQS
    link_with:
    - SQSTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
sources:
- https://github.com/CocoaPods/Specs.git
workspace: AWSiOSSDKv2
```


After
`pod icp podfile Podfile`
```
target_definitions:
- name: Pods
  link_with_first_target: true
  user_project_path: AWSCore
  link_with:
  - AWSCoreTests
  - AWSiOSSDKAnalyticsTests
  dependencies:
  - Bolts:
    - "~> 1.1.0"
  - Mantle:
    - "~> 1.4"
  - TMCache:
    - "~> 1.2.1"
  - XMLDictionary:
    - "~> 1.4.0"
  - UICKeyChainStore:
    - "~> 2.0"
  - Reachability:
    - "~> 3.1"
  - GZIP:
    - "~> 1.0.3"
  - FMDB:
    - "~> 2.4"
  children:
  - name: :AutoScaling
    user_project_path: AutoScaling
    link_with:
    - AutoScalingTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :CloudWatch
    user_project_path: CloudWatch
    link_with:
    - CloudWatchTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :DynamoDB
    user_project_path: DynamoDB
    link_with:
    - DynamoDBTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :EC2
    user_project_path: EC2
    link_with:
    - EC2Tests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :ElasticLoadBalancing
    user_project_path: ElasticLoadBalancing
    link_with:
    - ElasticLoadBalancingTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :Kinesis
    user_project_path: Kinesis
    link_with:
    - KinesisTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :S3
    user_project_path: S3
    link_with:
    - S3Tests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SES
    user_project_path: SES
    link_with:
    - SESTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SimpleDB
    user_project_path: SimpleDB
    link_with:
    - SimpleDBTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SNS
    user_project_path: SNS
    link_with:
    - SNSTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
  - name: :SQS
    user_project_path: SQS
    link_with:
    - SQSTests
    dependencies:
    - Bolts:
      - "~> 1.1.0"
    - Mantle:
      - "~> 1.4"
    - TMCache:
      - "~> 1.2.1"
    - XMLDictionary:
      - "~> 1.4.0"
    - UICKeyChainStore:
      - "~> 2.0"
    - Reachability:
      - "~> 3.1"
    - GZIP:
      - "~> 1.0.3"
    - FMDB:
      - "~> 2.4"
sources:
- https://github.com/CocoaPods/Specs.git
workspace: AWSiOSSDKv2
```

```
$ diff Desktop/aws_old.txt Desktop/aws_new.txt                                                                                                                                                                                                                                                            

$
```