### PR TITLE
Fixed Complier Warning: "Auto property synthesis will not synthesize pro...

### DIFF
--- a/AWSS3/AWSS3TransferManager.m
+++ b/AWSS3/AWSS3TransferManager.m
@@ -700,6 +700,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 @end
 
 @implementation AWSS3TransferManagerUploadRequest
+@dynamic body;
 
 - (instancetype)init {
     if (self = [super init]) {


### PR DESCRIPTION
When using Xcode 6.3 AWSS3TransferManager.h generates a compiler warning as follows:

`Auto property synthesis will not synthesize property 'body'; it will be implemented by its superclass, use @dynamic to acknowledge intention`

I've made a pull request which seems to take care of the issue by adding the specified @dynamic call to the @implementation.

Thanks, Sean.