### PR TITLE
Stop hiding errors when sending Kinesis requests

### DIFF
--- a/AWSKinesis/AWSKinesisRecorder.m
+++ b/AWSKinesis/AWSKinesisRecorder.m
@@ -318,7 +318,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
                         putRecordsInput.records = records;
                         AWSLogVerbose(@"putRecordsInput: [%@]", putRecordsInput);
                         outputTask = [outputTask continueWithSuccessBlock:^id(AWSTask *task) {
-                            return [[kinesis putRecords:putRecordsInput] continueWithSuccessBlock:^id(AWSTask *task) {
+                            return [[kinesis putRecords:putRecordsInput] continueWithBlock:^id(AWSTask *task) {
                                 if (task.error) {
                                     AWSLogError(@"Error: [%@]", task.error);
                                 }


### PR DESCRIPTION
Kinesis http request were failing silently, they should be displayed in the AWS log