### PR TITLE
TARGET_IPHONE_SIMULATOR has been deprecated

### DIFF
--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
@@ -1106,7 +1106,7 @@ static NSString *_defaultService;
     
     if (itemClass == kSecClassGenericPassword) {
         query[(__bridge __strong id)(kSecAttrService)] = _service;
-#if !TARGET_IPHONE_SIMULATOR
+#if !TARGET_OS_SIMULATOR
         if (_accessGroup) {
             query[(__bridge __strong id)kSecAttrAccessGroup] = _accessGroup;
         }


### PR DESCRIPTION
Update to use new build flag for detecting simulator. May need to include TargetConditionals.h if used in Swift code, which is not the case here.