### PR TITLE
Added correct URL for GovCloud STS endpoint

### DIFF
--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -376,6 +376,8 @@ NSString *const AWSServiceNameSTS = @"sts";
     } else if (serviceType == AWSServiceSTS) {
         if (regionType == AWSRegionCNNorth1) {
             URL = [NSURL URLWithString:@"https://sts.cn-north-1.amazonaws.com"];
+        } else if (regionType == AWSRegionUSGovWest1) {
+            URL = [NSURL URLWithString:@"https://sts.us-gov-west-1.amazonaws.com"];
         } else {
             URL = [NSURL URLWithString:@"https://sts.amazonaws.com"];
         }

--- a/AWSCoreTests/AWSServiceTests.m
+++ b/AWSCoreTests/AWSServiceTests.m
@@ -334,6 +334,28 @@
     XCTAssertEqualObjects(endpoint.URL, [NSURL URLWithString:@"https://(null).(null).amazonaws.com"]);
     XCTAssertEqualObjects(endpoint.hostName, @"(null).(null).amazonaws.com");
     XCTAssertFalse(endpoint.useUnsafeURL);
+
+    endpoint = [[AWSEndpoint alloc] initWithRegion:AWSRegionUSGovWest1
+                                           service:AWSServiceS3
+                                      useUnsafeURL:NO];
+    XCTAssertEqual(endpoint.regionType, AWSRegionUSGovWest1);
+    XCTAssertEqualObjects(endpoint.regionName, @"us-gov-west-1");
+    XCTAssertEqual(endpoint.serviceType, AWSServiceS3);
+    XCTAssertEqualObjects(endpoint.serviceName, @"s3");
+    XCTAssertEqualObjects(endpoint.URL, [NSURL URLWithString:@"https://s3-us-gov-west-1.amazonaws.com"]);
+    XCTAssertEqualObjects(endpoint.hostName, @"s3-us-gov-west-1.amazonaws.com");
+    XCTAssertFalse(endpoint.useUnsafeURL);
+
+    endpoint = [[AWSEndpoint alloc] initWithRegion:AWSRegionUSGovWest1
+                                           service:AWSServiceSTS
+                                      useUnsafeURL:NO];
+    XCTAssertEqual(endpoint.regionType, AWSRegionUSGovWest1);
+    XCTAssertEqualObjects(endpoint.regionName, @"us-gov-west-1");
+    XCTAssertEqual(endpoint.serviceType, AWSServiceSTS);
+    XCTAssertEqualObjects(endpoint.serviceName, @"sts");
+    XCTAssertEqualObjects(endpoint.URL, [NSURL URLWithString:@"https://sts.us-gov-west-1.amazonaws.com"]);
+    XCTAssertEqualObjects(endpoint.hostName, @"sts.us-gov-west-1.amazonaws.com");
+    XCTAssertFalse(endpoint.useUnsafeURL);
 }
 
 - (void)testServiceManager {


### PR DESCRIPTION
Without this change, calls STS requests with the `AWSRegionUSGovWest1` region get assigned an endpoint with the `https://sts.amazonaws.com` URL, causing authentication requests with that region to fail. This change assigns the correct URL for the GovCloud STS endpoint (`https://sts.us-gov-west-1.amazonaws.com`).