### PR TITLE
[AWSCore] Fix for `Ambiguous expansion of macro 'weakify'` warning

### DIFF
--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'AWSCore/*.{h,m}', 'AWSCore/**/*.{h,m}'
-  s.private_header_files = 'AWSCore/XMLDictionary/**/*.h', 'AWSCore/XMLWriter/**/*.h', 'AWSCore/FMDB/AWSFMDatabase+Private.h'
+  s.private_header_files = 'AWSCore/XMLDictionary/**/*.h', 'AWSCore/XMLWriter/**/*.h', 'AWSCore/FMDB/AWSFMDatabase+Private.h', 'AWSCore/Mantle/extobjc/*.h'
 end


### PR DESCRIPTION
## Summary

If including AWS SDK by using `use_frameworks!` together with other libraries that leverages on `jspahrsummers/libextobjc`, Xcode shows a warning when one of the macros, defined in `libextobjc`'s headers, is used.

## Pull request

The AWSCore Podspec has been updated to include the Mantle's extobjc headers as private.  

## Example

Project's Podfile:

```ruby
source 'https://github.com/CocoaPods/Specs.git'

use_frameworks!

platform :ios, :deployment_target => '8.1'

pod 'AWSCore'
pod 'libextobjc'
```

Following Xcode warning shows up during compile time:

`Ambiguous expansion of macro 'weakify'`

## References

https://github.com/Mantle/Mantle/issues/488