### PR TITLE
Fixed timer schedule bug

### DIFF
--- a/AWSIoT/Internal/MQTTSDK/MQTTSession.m
+++ b/AWSIoT/Internal/MQTTSDK/MQTTSession.m
@@ -496,19 +496,14 @@
                             const UInt8 *bytes = [[msg data] bytes];
                             if (bytes[1] == 0) {
                                 status = MQTTSessionStatusConnected;
-                                timer = [[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSinceNow:1.0]
-                                                                 interval:1.0
-                                                                   target:self
-                                                                 selector:@selector(timerHandler:)
-                                                                 userInfo:nil
-                                                                  repeats:YES];
-                                if(_connectionHandler){
+                                                                if(_connectionHandler){
                                     _connectionHandler(MQTTSessionEventConnected);
                                 }
                                 
+                                timer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(timerHandler:) userInfo:nil repeats:YES];
                                 [_delegate session:self handleEvent:MQTTSessionEventConnected];
                                 
-                                [runLoop addTimer:timer forMode:runLoopMode];
+                                
                             }
                             else {
                                 [self error:MQTTSessionEventConnectionRefused];


### PR DESCRIPTION
There's a bug, certainly against iOS 9.3, that causes the keepalive timer to not actually run in WSS mode.

This causes the MQTT connection to drop, and reconnect, every 60s on an idle connection. This change fixes that scheduling issue.
