### PR TITLE
avoid infinite loop on network failure

### DIFF
--- a/AWSKinesis/AWSKinesisRecorder.m
+++ b/AWSKinesis/AWSKinesisRecorder.m
@@ -167,7 +167,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
                 }
             }
         }
-        return nil;
+        return task;
     }];
 }
 


### PR DESCRIPTION
When `[AWSKinesisRecorder -submitRecordsForStream:records:partitionKeys:putPartitionKeys:retryPartitionKeys:]` fails due to network error, it fails to report this error to `AWSAbstractKinesisRecorder`. As a result, it attempts to resend them again immediately, without updating the `retry_count`, causing it to loop until network connectivity is restored, while consuming intensive CPU resources. In my opinion, the retry count shouldn't be updated in this case since this is not a server error, but rather the entire submit should be aborted and retried by the calling application at a later time.