### PR TITLE
Add ability to invalidate an AWSS3TransferUtility

### DIFF
--- a/AWSS3/AWSS3TransferUtility.h
+++ b/AWSS3/AWSS3TransferUtility.h
@@ -26,6 +26,13 @@ NS_ASSUME_NONNULL_BEGIN
 @class AWSS3TransferUtilityDownloadExpression;
 
 /**
+ The invalidation completion handler.
+
+ @param error Returns the error that caused invalidation, or nil if the invalidation was explicit.
+ */
+typedef void (^AWSS3TransferUtilityInvalidationCompletionHandlerBlock) (NSError * __nullable error);
+
+/**
  The upload completion handler.
 
  @param task  The upload task object.
@@ -302,6 +309,15 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
                                 downloadTask:(nullable void (^)(AWSS3TransferUtilityDownloadTask *downloadTask,
                                                                 AWSS3TransferUtilityDownloadProgressBlock * __nullable downloadProgressBlockReference,
                                                                 AWSS3TransferUtilityDownloadCompletionHandlerBlock * __nullable completionHandlerReference))downloadBlocksAssigner;
+
+/**
+  Invalidates the underlying NSURLSession.
+
+  @param cancel Cancel all tasks before invalidating
+  @param completionHandler Completion handler to be called after all outstanding tasks have been canceled or have finished.
+ */
+- (void)invalidateAndCancel:(BOOL)cancel withCompletionHandler:(AWSS3TransferUtilityInvalidationCompletionHandlerBlock)completionHandler;
+
 #pragma clang diagnostic pop
 
 /**


### PR DESCRIPTION
Background: It's not possible to change the configuration of an already created `NSURLSession` - it must instead be invalidated and re-created with the updated configuration.  `AWSS3TransferUtility` inherits this limitation, so it should also expose the invalidation functionality.

This is necessary, for example, if one wants to change the `allowsCellularAccess` configuration property on an already running `NSURLSession`.

Note: I opted for parameterized cancelation to keep the API small, but if this isn't desired, I could split into two different methods (much like the underlying `invalidateAndCancel` and `finishTasksAndInvalidate` methods on `NSURLSession`)