### PR TITLE
Add ability to invalidate an AWSS3TransferUtility

### DIFF
--- a/AWSCore/Utility/AWSSynchronizedMutableDictionary.h
+++ b/AWSCore/Utility/AWSSynchronizedMutableDictionary.h
@@ -19,6 +19,7 @@
 
 - (id)objectForKey:(id)aKey;
 - (void)removeObjectForKey:(id)aKey;
+- (void)removeObject:(id)object;
 - (void)setObject:(id)anObject forKey:(id <NSCopying>)aKey;
 - (NSArray *)allKeys;
 

--- a/AWSCore/Utility/AWSSynchronizedMutableDictionary.m
+++ b/AWSCore/Utility/AWSSynchronizedMutableDictionary.m
@@ -63,4 +63,15 @@
     return allKeys;
 }
 
+- (void)removeObject:(id)object {
+    dispatch_sync(self.dispatchQueue, ^{
+        for (NSString *key in self.dictionary) {
+            if (object == self.dictionary[key]) {
+                [self.dictionary removeObjectForKey:key];
+                break;
+            }
+        }
+    });
+}
+
 @end

--- a/AWSS3/AWSS3TransferUtility.h
+++ b/AWSS3/AWSS3TransferUtility.h
@@ -16,7 +16,7 @@
 #import <UIKit/UIKit.h>
 #import <AWSCore/AWSCore.h>
 
-FOUNDATION_EXPORT NSString *const AWSS3SessionInvalidatedNotification;
+FOUNDATION_EXPORT NSString *const AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -199,6 +199,10 @@ typedef void (^AWSS3TransferUtilityDownloadProgressBlock) (AWSS3TransferUtilityD
 
 /**
  Removes the service client associated with the key and release it.
+
+ The underlying NSURLSession is invalidated, and after the invalidation has completed the transfer is utility removed.
+
+ Observe the AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification to be informed when this has occurred.
 
  @warning Before calling this method, make sure no method is running on this client.
 

--- a/AWSS3/AWSS3TransferUtility.h
+++ b/AWSS3/AWSS3TransferUtility.h
@@ -16,6 +16,8 @@
 #import <UIKit/UIKit.h>
 #import <AWSCore/AWSCore.h>
 
+FOUNDATION_EXPORT NSString *const AWSS3SessionInvalidatedNotification;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class AWSS3TransferUtilityTask;

--- a/AWSS3/AWSS3TransferUtility.h
+++ b/AWSS3/AWSS3TransferUtility.h
@@ -16,9 +16,9 @@
 #import <UIKit/UIKit.h>
 #import <AWSCore/AWSCore.h>
 
-FOUNDATION_EXPORT NSString *const AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification;
-
 NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSString *const AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification;
 
 @class AWSS3TransferUtilityTask;
 @class AWSS3TransferUtilityUploadTask;

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -580,12 +580,7 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
 - (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
     [[NSNotificationCenter defaultCenter] postNotificationName:AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification object:self];
 
-    for (NSString *key in _serviceClients.allKeys) {
-        if (self == [_serviceClients objectForKey:key]) {
-            [_serviceClients removeObjectForKey:key];
-            break;
-        }
-    }
+    [_serviceClients removeObject:self];
 }
 
 

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -17,7 +17,7 @@
 #import "AWSS3PreSignedURL.h"
 #import "AWSSynchronizedMutableDictionary.h"
 
-NSString *const AWSS3SessionInvalidatedNotification = @"com.amazonaws.AWSS3TransferUtility.AWSS3SessionInvalidatedNotification";
+NSString *const AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification = @"com.amazonaws.AWSS3TransferUtility.AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification";
 NSString *const AWSS3TransferUtilityIdentifier = @"com.amazonaws.AWSS3TransferUtility.Identifier";
 NSTimeInterval const AWSS3TransferUtilityTimeoutIntervalForResource = 50 * 60; // 50 minutes
 NSString *const AWSS3TransferUtilityUserAgent = @"transfer-utility";
@@ -127,9 +127,9 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
 
 + (void)removeS3TransferUtilityForKey:(NSString *)key {
     AWSS3TransferUtility *transferUtility = [self S3TransferUtilityForKey:key];
-    if (transferUtility)
+    if (transferUtility) {
         [transferUtility.session invalidateAndCancel];
-    [_serviceClients removeObjectForKey:key];
+    }
 }
 
 - (instancetype)init {
@@ -578,8 +578,14 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
 }
 
 - (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
+    [[NSNotificationCenter defaultCenter] postNotificationName:AWSS3TransferUtilityURLSessionDidBecomeInvalidNotification object:self];
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:AWSS3SessionInvalidatedNotification object:self];
+    for (NSString *key in _serviceClients.allKeys) {
+        if (self == [_serviceClients objectForKey:key]) {
+            [_serviceClients removeObjectForKey:key];
+            break;
+        }
+    }
 }
 
 


### PR DESCRIPTION
Background: It's not possible to change the configuration of an already created NSURLSession - it must instead be invalidated and re-created with the updated configuration.  AWSS3TransferUtility inherits this limitation, so it should also expose the invalidation functionality.