### PR TITLE
Fixed memory issue when assigning data to AWSS3TransferUtilityDownloadTask

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -658,7 +658,11 @@ didFinishDownloadingToURL:(NSURL *)location {
             }
         }
     } else {
-        transferUtilityTask.data = [NSData dataWithContentsOfURL:location];
+        NSError *error = nil;
+        transferUtilityTask.data = [NSData dataWithContentsOfFile:location.path options:NSDataReadingMappedIfSafe error:&error];
+        if (!transferUtilityTask.data) {
+            transferUtilityTask.error = error;
+        }
     }
 }
 


### PR DESCRIPTION
If you start downloading a large file and the app crashes or is terminated by the system and then relaunched by the user the download will continue but AWSS3TransferUtilityDownloadTask will lose the location information. 

So when the completion delegate gets called
```
- (void)URLSession:(NSURLSession *)session
      downloadTask:(NSURLSessionDownloadTask *)downloadTask
didFinishDownloadingToURL:(NSURL *)location 
```
it tries to load the entire object in memory which crashes the app if downloading large files.
The file should be mapped into virtual memory instead.