### PR TITLE
Fixes for sending correct SSE-C parameters in Request Headers

### DIFF
--- a/AWSS3/AWSS3PreSignedURL.m
+++ b/AWSS3/AWSS3PreSignedURL.m
@@ -144,6 +144,10 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
      */
     
     NSMutableDictionary *headers = [NSMutableDictionary new];
+    NSString* key = @"x-amz-server-side-encryption-customer-algorithm";
+    if (requestParameters[key]) {
+        [headers setObject:requestParameters[key] forKey:key];
+    }
     [headers setObject:host forKey:@"host"];
     
     if ([contentType length] > 0) {

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -259,6 +259,9 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
         NSURL *presignedURL = task.result;
 
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:presignedURL];
+        for (id key in getPreSignedURLRequest.requestParameters) {
+            [request setValue:getPreSignedURLRequest.requestParameters[key] forHTTPHeaderField:key];
+        }
         request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
         request.HTTPMethod = @"PUT";
 
@@ -336,6 +339,9 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
         NSURL *presignedURL = task.result;
 
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:presignedURL];
+        for (id key in getPreSignedURLRequest.requestParameters) {
+            [request setValue:getPreSignedURLRequest.requestParameters[key] forHTTPHeaderField:key];
+        }
         request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
         request.HTTPMethod = @"GET";
 


### PR DESCRIPTION
Include x-amz-server-side-encryption-customer-algorithm in X-Amz-SignedHeaders in 2.3.6 version of SDK