### PR TITLE
Improved error handling for saveRecord

### DIFF
--- a/AWSKinesis/AWSAbstractKinesisRecorder.m
+++ b/AWSKinesis/AWSAbstractKinesisRecorder.m
@@ -158,8 +158,6 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                                               @"retry_count" : @0
                                               }
                            ];
-            
-            
             if (!result) {
                 AWSLogError(@"SQLite error. [%@]", db.lastError);
                 dbError = db.lastError;
@@ -186,6 +184,7 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
         __block NSError *fileError = nil;
         NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:databasePath
                                                                                     error:&fileError];
+        __block NSError *attError = nil;
         if (attributes) {
             NSUInteger fileSize = (NSUInteger)[attributes fileSize];
             [self.recorderHelper checkByteThresholdForNotification:notificationByteThreshold
@@ -205,8 +204,7 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                                    ];
                     if (!result) {
                         AWSLogError(@"SQLite error. [%@]", db.lastError);
-                        dbError = db.lastError;
-                        return [AWSTask taskWithError:dbError];
+                        attError = db.lastError;
                     }
                 }];
             }
@@ -216,6 +214,8 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
             return [AWSTask taskWithError:dbError];
         } else if (fileError) {
             return [AWSTask taskWithError:fileError];
+        } else if (attError) {
+            return [AWSTask taskWithError:attError];
         } else {
             return nil;
         }

--- a/AWSKinesis/AWSAbstractKinesisRecorder.m
+++ b/AWSKinesis/AWSAbstractKinesisRecorder.m
@@ -132,14 +132,14 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
     if ([data length] > 256 * 1024) {
         return [AWSTask taskWithError:[self.recorderHelper dataTooLargeError]];
     }
-    
+
     AWSFMDatabaseQueue *databaseQueue = self.databaseQueue;
     NSTimeInterval diskAgeLimit = self.diskAgeLimit;
     NSString *databasePath = self.databasePath;
     NSUInteger notificationByteThreshold = self.notificationByteThreshold;
     NSUInteger diskByteLimit = self.diskByteLimit;
     __weak id notificationSender = self;
-    
+
     return [[AWSTask taskWithResult:nil] continueWithSuccessBlock:^id(AWSTask *task) {
         // Inserts a new record to the database.
         __block NSError *dbError = nil;
@@ -163,7 +163,7 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                 dbError = db.lastError;
             }
         }];
-        
+
         if (!dbError && diskAgeLimit > 0) {
             [databaseQueue inDatabase:^(AWSFMDatabase *db) {
                 // Deletes old records exceeding the threshold.
@@ -180,7 +180,7 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                 }
             }];
         }
-        
+
         __block NSError *fileError = nil;
         NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:databasePath
                                                                                     error:&fileError];
@@ -209,7 +209,7 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                 }];
             }
         }
-        
+
         if (dbError) {
             return [AWSTask taskWithError:dbError];
         } else if (fileError) {

--- a/AWSKinesis/AWSAbstractKinesisRecorder.m
+++ b/AWSKinesis/AWSAbstractKinesisRecorder.m
@@ -132,17 +132,17 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
     if ([data length] > 256 * 1024) {
         return [AWSTask taskWithError:[self.recorderHelper dataTooLargeError]];
     }
-
+    
     AWSFMDatabaseQueue *databaseQueue = self.databaseQueue;
     NSTimeInterval diskAgeLimit = self.diskAgeLimit;
     NSString *databasePath = self.databasePath;
     NSUInteger notificationByteThreshold = self.notificationByteThreshold;
     NSUInteger diskByteLimit = self.diskByteLimit;
     __weak id notificationSender = self;
-
+    
     return [[AWSTask taskWithResult:nil] continueWithSuccessBlock:^id(AWSTask *task) {
         // Inserts a new record to the database.
-        __block NSError *error = nil;
+        __block NSError *dbError = nil;
         [databaseQueue inDatabase:^(AWSFMDatabase *db) {
             BOOL result = [db executeUpdate:
                            @"INSERT INTO record ("
@@ -158,15 +158,15 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                                               @"retry_count" : @0
                                               }
                            ];
-
-
+            
+            
             if (!result) {
                 AWSLogError(@"SQLite error. [%@]", db.lastError);
-                error = db.lastError;
+                dbError = db.lastError;
             }
         }];
-
-        if (!error && diskAgeLimit > 0) {
+        
+        if (!dbError && diskAgeLimit > 0) {
             [databaseQueue inDatabase:^(AWSFMDatabase *db) {
                 // Deletes old records exceeding the threshold.
                 BOOL result = [db executeUpdate:
@@ -178,17 +178,14 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                                ];
                 if (!result) {
                     AWSLogError(@"SQLite error. [%@]", db.lastError);
-                    error = db.lastError;
+                    dbError = db.lastError;
                 }
             }];
         }
-
-        if (error) {
-            return [AWSTask taskWithError:error];
-        }
-
+        
+        __block NSError *fileError = nil;
         NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:databasePath
-                                                                                    error:&error];
+                                                                                    error:&fileError];
         if (attributes) {
             NSUInteger fileSize = (NSUInteger)[attributes fileSize];
             [self.recorderHelper checkByteThresholdForNotification:notificationByteThreshold
@@ -208,17 +205,20 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                                    ];
                     if (!result) {
                         AWSLogError(@"SQLite error. [%@]", db.lastError);
-                        error = db.lastError;
-                        return;
+                        dbError = db.lastError;
+                        return [AWSTask taskWithError:dbError];
                     }
                 }];
-
             }
-        } else if (error) {
-            return [AWSTask taskWithError:error];
         }
-
-        return nil;
+        
+        if (dbError) {
+            return [AWSTask taskWithError:dbError];
+        } else if (fileError) {
+            return [AWSTask taskWithError:fileError];
+        } else {
+            return nil;
+        }
     }];
 }
 


### PR DESCRIPTION
This change intends to make the method ```saveRecord``` easier to read and understand

* Error returnings are now standardized throughout the method. 
* The former implementation was using the variable ```error``` everywhere. 
* Standard ```[AWSTaks taskWithError:error]``` returns where it was appropriate.
* Improved error logging