### PR TITLE
Adding parameter for AWSStaticCredentialsProvider init method

### DIFF
--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -102,11 +102,13 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
 
  @param accessKey An AWS Access key.
  @param secretKey An AWS Secret key.
+ @param secretKey An AWS Session key.
 
  @return An AWS credentials object.
  */
 - (instancetype)initWithAccessKey:(NSString *)accessKey
                         secretKey:(NSString *)secretKey;
+                        sessionKey:(NSString *)sessionKey;
 
 @end
 

--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -81,11 +81,12 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 @implementation AWSStaticCredentialsProvider
 
 - (instancetype)initWithAccessKey:(NSString *)accessKey
-                        secretKey:(NSString *)secretKey {
+                        secretKey:(NSString *)secretKey
+                       sessionKey:(NSString *)sessionKey {
     if (self = [super init]) {
         _internalCredentials = [[AWSCredentials alloc] initWithAccessKey:accessKey
                                                                secretKey:secretKey
-                                                              sessionKey:nil
+                                                              sessionKey:sessionKey
                                                               expiration:nil];
     }
     return self;


### PR DESCRIPTION
The [AWS SDK for Java](http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html) using **BasicAWSCredentials** to create a **BasicSessionCredentials** object.

Example 
```java
BasicSessionCredentials basic_session_creds = new BasicSessionCredentials(
   session_creds.getAccessKeyId(),
   session_creds.getSecretAccessKey(),
   session_creds.getSessionToken());

AmazonS3Client s3 = new AmazonS3Client(basic_session_creds);
```
But initialize method of **AWSStaticCredentialsProvider** haven't parameter *sessionKey*.
