### PR TITLE
Replace assert with if condition in AWSS3TransferUtility.m

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -666,8 +666,7 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
 - (void)URLSession:(NSURLSession *)session
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error {
-    if (!error) {
-        assert([task.response isKindOfClass:[NSHTTPURLResponse class]]);
+    if (!error && [task.response isKindOfClass:[NSHTTPURLResponse class]]) {
         NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)task.response;
 
         if (HTTPResponse.statusCode / 100 == 3


### PR DESCRIPTION
The assert will guaranteed crash the app unrecoverably if the type-check fails. By adding the type-check as an if condition, and removing the assert, the app will no longer crash unrecoverably if the type-check fails, and the code following it in the initial if condition will still not execute.