### PR TITLE
Replace assert with NSException, to provide the developer of an unacceptable state

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -666,8 +666,7 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
 - (void)URLSession:(NSURLSession *)session
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error {
-    if (!error) {
-        assert([task.response isKindOfClass:[NSHTTPURLResponse class]]);
+    if (!error && [task.response isKindOfClass:[NSHTTPURLResponse class]]) {
         NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)task.response;
 
         if (HTTPResponse.statusCode / 100 == 3

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -666,7 +666,10 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
 - (void)URLSession:(NSURLSession *)session
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error {
-    if (!error && [task.response isKindOfClass:[NSHTTPURLResponse class]]) {
+    if (!error) {
+        if (![task.response isKindOfClass:[NSHTTPURLResponse class]]) {
+            [NSException raise:@"Invalid NSURLSession state" format:@"The NSURLSessionTask returned with a response object in an invalid state."];
+        }
         NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)task.response;
 
         if (HTTPResponse.statusCode / 100 == 3


### PR DESCRIPTION
I have replaced the assert with a type check if statement that raises an NSException if it fails.

This issue came up because I experienced a crash caused by this assert, and had no information additional to know why it was acceptable to crash the application instead of allowing the developer to handle it gracefully. After some discussion, it has been communicated that the situation I encountered has an extremely low likelihood of occurring, and that if it did occur then the NSURLSession would be in an unacceptable, unrecoverable state. 

Replacing the assert with an NSException provides more information to future developers if they encounter this unlikely situation.