### PR TITLE
Allow for future expired/unauthed token calls to properly refresh the aws token.

### DIFF
--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -271,7 +271,6 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 @property (nonatomic, strong) AWSCredentials *internalCredentials;
 @property (atomic, assign, getter=isRefreshingCredentials) BOOL refreshingCredentials;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *cachedLogins;
-@property (atomic, assign) BOOL hasClearedIdentityId;
 
 @end
 
@@ -458,17 +457,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
                 return task;
             }
 
-            if (self.hasClearedIdentityId) {
-                return [AWSTask taskWithError:[NSError errorWithDomain:AWSCognitoCredentialsProviderErrorDomain
-                                                                  code:AWSCognitoCredentialsProviderInvalidConfiguration
-                                                              userInfo:@{NSLocalizedDescriptionKey : @"GetCredentialsForIdentity keeps failing. Clearing identityId did not help. Please check your Amazon Cognito Identity configuration."}]];
-            }
-
             AWSDDLogDebug(@"Resetting identity Id and calling getIdentityId");
             // if it's auth, reset id and refetch
             self.identityId = nil;
             providerRef.identityId = nil;
-            self.hasClearedIdentityId = YES;
 
             return [[providerRef logins] continueWithSuccessBlock:^id _Nullable(AWSTask<NSDictionary<NSString *,NSString *> *> * _Nonnull task) {
                 NSDictionary<NSString *,NSString *> *logins = task.result;
@@ -491,7 +483,14 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
                 getCredentialsRetry.logins = logins;
                 getCredentialsRetry.customRoleArn = customRoleArn;
 
-                return [self.cognitoIdentity getCredentialsForIdentity:getCredentialsRetry];
+                return [[self.cognitoIdentity getCredentialsForIdentity:getCredentialsRetry] continueWithBlock:^id _Nullable(AWSTask<AWSCognitoIdentityGetCredentialsForIdentityResponse *> * _Nonnull task) {
+                    if (task.error) {
+                        return [AWSTask taskWithError:[NSError errorWithDomain:AWSCognitoCredentialsProviderErrorDomain
+                                                                          code:AWSCognitoCredentialsProviderInvalidConfiguration
+                                                                      userInfo:@{NSLocalizedDescriptionKey : @"GetCredentialsForIdentity keeps failing. Clearing identityId did not help. Please check your Amazon Cognito Identity configuration."}]];
+                    }
+                    return task;
+                }];
             }];
         }
         return task;


### PR DESCRIPTION
This pull request allows for each (expired token/unauthed) call via aws to reset the identityId, call to refresh the developer aws token and then attempt to get valid aws credentials. If the second (nested) call fails then an error is returned stating that resetting the identityId was not enough to make the call. Subsequent calls go through the same process.