### PR TITLE
Added delegate method for completion of an intent

### DIFF
--- a/AWSLex/AWSLexInteractionKit.h
+++ b/AWSLex/AWSLexInteractionKit.h
@@ -100,6 +100,11 @@ typedef NS_ENUM(NSInteger, AWSLexSpeechEncoding) {
 - (void)interactionKit:(AWSLexInteractionKit *)interactionKit onDialogReadyForFulfillmentForIntent:(NSString *)intentName slots:(NSDictionary *)slots;
 
 /*
+ * Sent to delegate when the all the required slots are filled, the intent is fullfiled and the dialog is complete.
+ */
+- (void)interactionKit:(AWSLexInteractionKit *)interactionKit dialogFullfiledForIntent:(NSString *)intentName slots:(NSDictionary *)slots;
+
+/*
  * Sent to delegate incase you want to switch modes between text and voice input.
  */
 - (void)interactionKit:(AWSLexInteractionKit *)interactionKit

--- a/AWSLex/AWSLexInteractionKit.m
+++ b/AWSLex/AWSLexInteractionKit.m
@@ -775,6 +775,12 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
             [strongSelf.interactionDelegate interactionKit:strongSelf
                                            switchModeInput:input
                                           completionSource:nil];
+
+            [strongSelf dispatchBlockOnInteractionDelegateQueue:^{
+                if(strongSelf.interactionDelegate && [strongSelf.interactionDelegate respondsToSelector:@selector(interactionKit:dialogFullfiledForIntent:slots:)]) {
+                    [strongSelf.interactionDelegate interactionKit:strongSelf dialogFullfiledForIntent:response.intentName slots:response.slots];
+                }
+            }];
             return nil;
         }
         


### PR DESCRIPTION
Proposition of a new delegate method for The AWSLexInteractionKitDelegate to notify the client of the completion of an Intent.

Method is similar to `interactionKit:onDialogReadyForFulfillmentForIntent:slots:` but gets called when the whole intent is complete as a separate method instead of having to check again for the dialogeState in the body of the`interactionKit:switchModeInput:completionSource` delegate method.
