### PR TITLE
Fix issue reported in Shadow Operation Still In Progress! BUG! #565

### DIFF
--- a/AWSIoT/AWSIoTDataManager.m
+++ b/AWSIoT/AWSIoTDataManager.m
@@ -713,7 +713,7 @@ static void (^shadowMqttMessageHandler)(NSObject *mqttClient, NSString *topic, N
             // Start the shadow operation timer.
             //
             shadow.timer = [NSTimer timerWithTimeInterval:shadow.operationTimeout target:self selector: @selector(shadowOperationTimeoutOnTimer:) userInfo:name repeats:NO];
-            
+            [[NSRunLoop mainRunLoop] addTimer:shadow.timer forMode:NSRunLoopCommonModes];
             //
             // Add the version number (if known and versioning is enabled) and
             // client token properties to the state dictionary.


### PR DESCRIPTION
In my understanding - The main reason for this is that shadow timer is neither using the scheduledTimerWithTimeInterval nor adding it to the run loop using [NSRunLoop mainRunLoop] addTimer.

I'm referring to the following lines in the AWSIotDataManager.m
shadow.timer = [NSTimer timerWithTimeInterval:shadow.operationTimeout target:self selector: @selector(shadowOperationTimeoutOnTimer:) userInfo:name repeats:NO];

This is based on my own testing, seeing why how other timers in SDK are coded and also based on what i read in different stack overflow threads.

http://stackoverflow.com/questions/10522928/run-repeating-nstimer-with-gcd

thanks
Ram