### PR TITLE
Remove Transfer-Encoding from streaming signature

### DIFF
--- a/AWSCore/Authentication/AWSSignature.m
+++ b/AWSCore/Authentication/AWSSignature.m
@@ -219,7 +219,6 @@ NSString *const AWSSignatureV4Terminator = @"aws4_request";
         [urlRequest setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[AWSS3ChunkedEncodingInputStream computeContentLengthForChunkedData:contentLength]]
           forHTTPHeaderField:@"Content-Length"];
         [urlRequest setValue:nil forHTTPHeaderField:@"Content-Length"]; //remove Content-Length header if it is a HTTPBodyStream
-        [urlRequest setValue:@"Chunked" forHTTPHeaderField:@"Transfer-Encoding"];
         [urlRequest addValue:@"aws-chunked" forHTTPHeaderField:@"Content-Encoding"]; //add aws-chunked keyword for s3 chunk upload
         [urlRequest setValue:[NSString stringWithFormat:@"%lu", (unsigned long)contentLength] forHTTPHeaderField:@"x-amz-decoded-content-length"];
     } else {


### PR DESCRIPTION
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html 
doesn't provide any detail related to `Transfer-Encoding` to be a valid 
header as a requirement. 

Additionally also Transfer-Encoding is used as part of signature 
request incorrectly because the transfer coding names are case 
insensitive[1] i.e when the canonical request is generated should
be generated as lower cased value instead.

```
content-encoding:aws-chunked
content-type:image/jpeg
host:***REDACTED***
transfer-encoding:Chunked
user-agent:aws-sdk-iOS/2.5.2 iOS/10.2 en_US transfer-manager
x-amz-acl:public-read
x-amz-content-sha256:STREAMING-AWS4-HMAC-SHA256-PAYLOAD
x-amz-date:20170413T050829Z
x-amz-decoded-content-length:1024000
```

[1] - http://greenbytes.de/tech/webdav/rfc7230.html#transfer.codings