### PR TITLE
Change APIGatewayClient to use timeouts provided by configuration

### DIFF
--- a/AWSAPIGateway/AWSAPIGatewayClient.m
+++ b/AWSAPIGateway/AWSAPIGatewayClient.m
@@ -427,4 +427,17 @@ static int defaultChunkSize = 1024;
     return [[value description] aws_stringWithURLEncoding];
 }
 
+- (void)setConfiguration:(AWSServiceConfiguration *)configuration {
+    _configuration = configuration;
+
+    // Setup a new NSURLSession configured with timeout from AWSServiceConfiguration
+    NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
+
+    sessionConfiguration.timeoutIntervalForRequest = configuration.timeoutIntervalForRequest;
+    sessionConfiguration.timeoutIntervalForResource = configuration.timeoutIntervalForResource;
+
+    _session = [NSURLSession sessionWithConfiguration:sessionConfiguration];
+}
+
+
 @end


### PR DESCRIPTION
The AWSAPIGatewayClient accepts and requires an AWSServiceConfiguration. It would be nice to be able to use the timeout interval properties on the configuration to set desired timeout intervals on the NSURLSession used by the AWSAPIGatewayClient.

This was discussed in https://github.com/aws/aws-sdk-ios/issues/101 in November 2015.