### PR TITLE
use UTF8 encoding to support username w/ accents

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -247,7 +247,7 @@ static NSString *const AWSCognitoUserPoolAppClientSecret = @"CognitoUserPoolAppC
         return nil;
 
     const char *cKey  = [self.userPoolConfiguration.clientSecret cStringUsingEncoding:NSASCIIStringEncoding];
-    const char *cData = [[userName stringByAppendingString:self.userPoolConfiguration.clientId] cStringUsingEncoding:NSASCIIStringEncoding];
+    const char *cData = [[userName stringByAppendingString:self.userPoolConfiguration.clientId] cStringUsingEncoding:NSUTF8StringEncoding];
 
     unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
 


### PR DESCRIPTION
Did test #679 with this change and it works. Tested username `ěščřžýáíé`.