### PR TITLE
Fixed Kinesis batchRecordsByteLimit default value is not correctly.

### DIFF
--- a/AWSKinesis/AWSAbstractKinesisRecorder.m
+++ b/AWSKinesis/AWSAbstractKinesisRecorder.m
@@ -25,7 +25,7 @@
 NSUInteger const AWSKinesisAbstractClientByteLimitDefault = 5 * 1024 * 1024; // 5MB
 NSTimeInterval const AWSKinesisAbstractClientAgeLimitDefault = 0.0; // Keeps the data indefinitely unless it hits the size limit.
 NSString *const AWSKinesisAbstractClientUserAgent = @"recorder";
-NSUInteger const AWSKinesisAbstractClientBatchRecordByteLimitDefault = 512 * 1024 * 1024;
+NSUInteger const AWSKinesisAbstractClientBatchRecordByteLimitDefault = 512 * 1024; // 512KB
 NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazonaws/AWSKinesisRecorder";
 
 @protocol AWSKinesisRecorderHelper <NSObject>


### PR DESCRIPTION
In [AWSAbstractKinesisRecorder.h#L46](https://github.com/aws/aws-sdk-ios/blob/master/AWSKinesis/AWSAbstractKinesisRecorder.h#L46), `batchRecordsByteLimit` property doc describe default value will be 512KB.
But in [AWSAbstractKinesisRecorder.m#L28](https://github.com/aws/aws-sdk-ios/blob/master/AWSKinesis/AWSAbstractKinesisRecorder.m#L28), default value is not 512KB. It is 512 **MB**.

[PutRecords API](http://docs.aws.amazon.com/ja_jp/kinesis/latest/APIReference/API_PutRecords.html) limit is 5MB.
> up to a limit of 5 MB for the entire request, including partition keys.

[PutRecoreBatch API](http://docs.aws.amazon.com/ja_jp/firehose/latest/APIReference/API_PutRecordBatch.html) limit is 4MB.
> up to a limit of 4 MB for the entire request. 


So I expect that if exceed not yet sent records byte 4MB(Firehose) or 5MB(Stream), all of the records will not send(API and AWSTask will fail) and will not be delete(not increment `retry_count`  field).