### PR TITLE
Fix error produced in iOS 11 beta 3 when compiling AWSCore

### DIFF
--- a/AWSCore/Logging/AWSDDOSLogger.m
+++ b/AWSCore/Logging/AWSDDOSLogger.m
@@ -55,16 +55,16 @@ static AWSDDOSLogger *sharedInstance;
         
         switch (logMessage->_flag) {
             case AWSDDLogFlagError     :
-                os_log_error(OS_LOG_DEFAULT, msg);
+                os_log_error(OS_LOG_DEFAULT, "%@", msg);
                 break;
             case AWSDDLogFlagWarning   :
             case AWSDDLogFlagInfo      :
-                os_log_info(OS_LOG_DEFAULT, msg);
+                os_log_info(OS_LOG_DEFAULT, "%@", msg);
                 break;
             case AWSDDLogFlagDebug     :
             case AWSDDLogFlagVerbose   :
             default                 :
-                os_log_debug(OS_LOG_DEFAULT, msg);
+                os_log_debug(OS_LOG_DEFAULT, "%@", msg);
                 break;
         }
     }


### PR DESCRIPTION
The description of the `os_log_error` macro say that _format_ argument must be a string constant. Xcode help states following:

> format
> A format string to generate a human-readable log message when the log
> line is decoded.  This string must be a constant string, not dynamically
> generated.  Supports all standard printf types and %@ (objects).