### PR TITLE
AWSS3PreSignedURLBuilder configuration copy

### DIFF
--- a/AWSS3/AWSS3PreSignedURL.m
+++ b/AWSS3/AWSS3PreSignedURL.m
@@ -21,6 +21,10 @@
 #import "AWSSynchronizedMutableDictionary.h"
 #import <CommonCrypto/CommonCrypto.h>
 
+@interface AWSEndpoint()
+- (void) setRegion:(AWSRegionType)regionType service:(AWSServiceType)serviceType;
+@end
+
 NSString *const AWSS3PresignedURLErrorDomain = @"com.amazonaws.AWSS3PresignedURLErrorDomain";
 
 static NSString *const AWSS3PreSignedURLBuilderAcceleratedEndpoint = @"s3-accelerate.amazonaws.com";
@@ -129,6 +133,9 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
             _configuration.endpoint = [[AWSEndpoint alloc] initWithRegion:_configuration.regionType
                                                                   service:AWSServiceS3
                                                              useUnsafeURL:NO];
+        }else {
+            [_configuration.endpoint setRegion:_configuration.regionType
+                                       service:AWSServiceS3];
         }
     }
 

--- a/AWSS3/AWSS3PreSignedURL.m
+++ b/AWSS3/AWSS3PreSignedURL.m
@@ -124,9 +124,12 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 - (instancetype)initWithConfiguration:(AWSServiceConfiguration *)configuration {
     if (self = [super init]) {
         _configuration = [configuration copy];
-        _configuration.endpoint = [[AWSEndpoint alloc] initWithRegion:_configuration.regionType
-                                                              service:AWSServiceS3
-                                                         useUnsafeURL:NO];
+        
+        if(!configuration.endpoint){
+            _configuration.endpoint = [[AWSEndpoint alloc] initWithRegion:_configuration.regionType
+                                                                  service:AWSServiceS3
+                                                             useUnsafeURL:NO];
+        }
     }
 
     return self;


### PR DESCRIPTION
only create a new copy of `configuration.endpoint` for `AWSS3PreSignedURLBuilder` if one does not exist
already.

see Issue: https://github.com/aws/aws-sdk-ios/issues/708 for more details