### PR TITLE
Fixes compilation errors in AWSDDODLogger reported by Xcode 9.

### DIFF
--- a/AWSCore/Logging/AWSDDOSLogger.m
+++ b/AWSCore/Logging/AWSDDOSLogger.m
@@ -55,16 +55,16 @@ static AWSDDOSLogger *sharedInstance;
         
         switch (logMessage->_flag) {
             case AWSDDLogFlagError     :
-                os_log_error(OS_LOG_DEFAULT, msg);
+                os_log_error(OS_LOG_DEFAULT, "%{public}s", msg);
                 break;
             case AWSDDLogFlagWarning   :
             case AWSDDLogFlagInfo      :
-                os_log_info(OS_LOG_DEFAULT, msg);
+                os_log_info(OS_LOG_DEFAULT, "%{public}s", msg);
                 break;
             case AWSDDLogFlagDebug     :
             case AWSDDLogFlagVerbose   :
             default                 :
-                os_log_debug(OS_LOG_DEFAULT, msg);
+                os_log_debug(OS_LOG_DEFAULT, "%{public}s", msg);
                 break;
         }
     }


### PR DESCRIPTION
`AWSDDOSLogger` fails to compile in Xcode 9 with this error (and two others on subsequent lines):

`AWSDDOSLogger.m:58:17: error: static_assert failed "format argument must be a string constant" os_log_error(OS_LOG_DEFAULT, msg);`

This PR addresses the issue reported here: https://github.com/aws/aws-sdk-ios/issues/706

Please let me know if you'd like any changes, thanks!