### PR TITLE
Signature mismatch fix

### DIFF
--- a/AWSCore/Authentication/AWSSignature.m
+++ b/AWSCore/Authentication/AWSSignature.m
@@ -186,7 +186,7 @@ NSString *const AWSSignatureV4Terminator = @"aws4_request";
     //        [request.urlRequest setURL:request.url];
     //    }
 
-    NSDate *date = [NSDate aws_clockSkewFixedDate];
+    NSDate *date = [NSDate aws_dateFromString:[urlRequest valueForHTTPHeaderField:@"X-Amz-Date"] format:AWSDateISO8601DateFormat2];
     NSString *dateStamp = [date aws_stringValue:AWSDateShortDateFormat1];
     //NSString *dateTime  = [date aws_stringValue:AWSDateAmzDateFormat];
 

--- a/AWSS3/AWSS3RequestRetryHandler.m
+++ b/AWSS3/AWSS3RequestRetryHandler.m
@@ -42,7 +42,7 @@
         switch (error.code) {
             case AWSServiceErrorSignatureDoesNotMatch:
                 //may happened right after generating AWS temporary credentials due to the massively distributed nature of Amazon S3, just retry the request
-                retryType = AWSNetworkingRetryTypeShouldRetry;
+                retryType = AWSNetworkingRetryTypeShouldCorrectClockSkewAndRetry;
                 break;
                 
             default:


### PR DESCRIPTION
These changes are to address intermittent `AWSServiceErrorSignatureDoesNotMatch` errors when attempting to perform `[AWSS3 putObject:]` requests to GovCloud (`AWSRegionUSGovWest1`). The errors we received seemed to relate to issue #739 in which the submitter had suggested a change to make sure the `dateStamp` used in chunk signing was the same as that in the `X-Amz-Date` header value.

In the process of investigating the signature errors, we discovered what appears to be a logic bug with `AWSS3RequestRetryHandler`, where the `retryType` from `super` can be overridden when the error code is `AWSServiceErrorSignatureDoesNotMatch`, preventing the clock skew from being corrected. We made a change to make sure the clock skew is corrected in this particular circumstance.

After applying these two changes, we are no longer receiving intermittent errors.