### PR TITLE
Distinguish keychain for different credential providers

### DIFF
--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -370,7 +370,7 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     _useEnhancedFlow = !unauthRoleArn && !authRoleArn;
 
     // initialize keychain - name spaced by app bundle and identity pool id
-    _keychain = [AWSUICKeyChainStore keyChainStoreWithService:[NSString stringWithFormat:@"%@.%@.%@", [NSBundle mainBundle].bundleIdentifier, [AWSCognitoCredentialsProvider class], identityProvider.identityPoolId]];
+    _keychain = [AWSUICKeyChainStore keyChainStoreWithService:[NSString stringWithFormat:@"%@.%@.%@", [NSBundle mainBundle].bundleIdentifier, [self class], identityProvider.identityPoolId]];
 
     // If the identity provider has an identity id, use it
     if (identityProvider.identityId) {


### PR DESCRIPTION
Distinguish keychain place for different credential providers by deriving from AWSCognitoCredentialsProvider

Using different Cognito credential providers  (authenticated and unauthenticated) for same identity pool causes to interference. All providers shares same keychain in order to cache credentials.