### PR TITLE
Change comment to remove a warning in Xcode

### DIFF
--- a/AWSPinpoint/AWSPinpointSessionClient.m
+++ b/AWSPinpoint/AWSPinpointSessionClient.m
@@ -479,7 +479,7 @@ typedef void(^voidBlock)(void);
     [dateFormatter setDateFormat:AWSPinpointSessionIDTimeFormat];
     NSString *timestamp_time = [dateFormatter stringFromDate:tDate];
     
-    //<AppKey> - <UniqueID> - <Day> - <Time>
+    //Session ID as String, formmatted as <AppKey> - <UniqueID> - <Day> - <Time>
     return [NSString stringWithFormat:@"%@%c%@%c%@%c%@", appKey, AWSPinpointSessionIDDelimiter, uniqID, AWSPinpointSessionIDDelimiter, timestamp_day, AWSPinpointSessionIDDelimiter, timestamp_time];
 };
 


### PR DESCRIPTION
This change alters a comment that is flagging a warning in Xcode.  No functional changes are included.