### PR TITLE
Kinesis: avoid relying on partition_key as row id in AWSAbstractKinesisRecorder

### DIFF
--- a/AWSKinesis/AWSAbstractKinesisRecorder.m
+++ b/AWSKinesis/AWSAbstractKinesisRecorder.m
@@ -34,9 +34,9 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
 
 - (AWSTask *)submitRecordsForStream:(NSString *)streamName
                             records:(NSArray *)temporaryRecords
-                      partitionKeys:(NSArray *)partitionKeys
-                   putPartitionKeys:(NSMutableArray *)putPartitionKeys
-                 retryPartitionKeys:(NSMutableArray *)retryPartitionKeys
+                             rowIds:(NSArray *)rowIds
+                          putRowIds:(NSMutableArray *)putRowIds
+                        retryRowIds:(NSMutableArray *)retryRowIds
                                stop:(BOOL *)stop;
 
 - (NSError *)dataTooLargeError;
@@ -282,9 +282,9 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
                     AWSTask *submitTask = \
                         [self.recorderHelper submitRecordsForStream:streamName
                                                             records:temporaryRecords
-                                                      partitionKeys:rowIds
-                                                   putPartitionKeys:putRowIds
-                                                 retryPartitionKeys:retryRowIds
+                                                             rowIds:rowIds
+                                                          putRowIds:putRowIds
+                                                        retryRowIds:retryRowIds
                                                                stop:&stop];
 
                     [submitTask waitUntilFinished];

--- a/AWSKinesis/AWSFirehoseRecorder.m
+++ b/AWSKinesis/AWSFirehoseRecorder.m
@@ -156,9 +156,9 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 
 - (AWSTask *)submitRecordsForStream:(NSString *)streamName
                             records:(NSArray *)temporaryRecords
-                      partitionKeys:(NSArray *)partitionKeys
-                   putPartitionKeys:(NSMutableArray *)putPartitionKeys
-                 retryPartitionKeys:(NSMutableArray *)retryPartitionKeys
+                             rowIds:(NSArray *)rowIds
+                          putRowIds:(NSMutableArray *)putRowIds
+                        retryRowIds:(NSMutableArray *)retryRowIds
                                stop:(BOOL *)stop {
     NSMutableArray *records = [NSMutableArray new];
 
@@ -196,9 +196,9 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
                 // we should retry. So, don't delete the row from the database.
                 if (![resultEntry.errorCode isEqualToString:@"Throttling"]
                     && ![resultEntry.errorCode isEqualToString:@"ServiceUnavailable"]) {
-                    [putPartitionKeys addObject:partitionKeys[i]];
+                    [putRowIds addObject:rowIds[i]];
                 } else {
-                    [retryPartitionKeys addObject:partitionKeys[i]];
+                    [retryRowIds addObject:rowIds[i]];
                 }
             }
         }

--- a/AWSKinesis/AWSKinesisRecorder.m
+++ b/AWSKinesis/AWSKinesisRecorder.m
@@ -156,9 +156,9 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 
 - (AWSTask *)submitRecordsForStream:(NSString *)streamName
                             records:(NSArray *)temporaryRecords
-                      partitionKeys:(NSArray *)partitionKeys
-                   putPartitionKeys:(NSMutableArray *)putPartitionKeys
-                 retryPartitionKeys:(NSMutableArray *)retryPartitionKeys
+                             rowIds:(NSArray *)rowIds
+                          putRowIds:(NSMutableArray *)putRowIds
+                        retryRowIds:(NSMutableArray *)retryRowIds
                                stop:(BOOL *)stop {
     NSMutableArray *records = [NSMutableArray new];
 
@@ -196,9 +196,9 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
                 // we should retry. So, don't delete the row from the database.
                 if (![resultEntry.errorCode isEqualToString:@"ProvisionedThroughputExceededException"]
                     && ![resultEntry.errorCode isEqualToString:@"InternalFailure"]) {
-                    [putPartitionKeys addObject:partitionKeys[i]];
+                    [putRowIds addObject:rowIds[i]];
                 } else {
-                    [retryPartitionKeys addObject:partitionKeys[i]];
+                    [retryRowIds addObject:rowIds[i]];
                 }
             }
         }


### PR DESCRIPTION
I found a bug in AWSAbstractKinesisRecorder where it uses `partition_key` as the key when deleting successfully transferred records. 

However, due to the ability to specify arbitrary partition keys per record, they are now not guaranteed to be random UUIDs. This, paired with multiple concurrent writes, results in records being deleted before sending.

I solved the problem by using `rowid` which is a built-in SQLite column guaranteed to be unique.