### PR TITLE
Avoid throwing an exception in production

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -756,8 +756,9 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error {
     if (!error) {
+        NSAssert([task.response isKindOfClass:[NSHTTPURLResponse class]], @"Expected response of type NSHTTPURLResponse");
         if (![task.response isKindOfClass:[NSHTTPURLResponse class]]) {
-            [NSException raise:@"Invalid NSURLSession state" format:@"Expected response of type  %@", @"NSHTTPURLResponse"];
+            error = [NSError errorWithDomain:AWSS3TransferUtilityErrorDomain code:AWSS3TransferUtilityErrorUnknown userInfo:nil];
         }
         
         NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)task.response;


### PR DESCRIPTION
This replaces the exception with an assertion and assigns an error. The assertion will also raise an exception, but can be disabled in build settings. This enables us to maintain existing behaviour during development, but avoid exceptions in production.

This is regarding issue #490.
  