### PR TITLE
Declare framework dependencies in podspecs

### DIFF
--- a/AWSCognitoIdentityProvider.podspec
+++ b/AWSCognitoIdentityProvider.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
+  s.frameworks   = 'Security', 'UIKit'
   s.dependency 'AWSCognitoIdentityProviderASF', '1.0.1'
   s.dependency 'AWSCore', '2.6.11'
   s.source_files = 'AWSCognitoIdentityProvider/**/*.{h,m,c}'

--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.source       = { :git => 'https://github.com/aws/aws-sdk-ios.git',
                      :tag => s.version}
-  s.frameworks   = 'UIKit', 'Foundation', 'SystemConfiguration'
+  s.frameworks   = 'CoreGraphics', 'UIKit', 'Foundation', 'SystemConfiguration', 'Security'
   s.libraries    = 'z', 'sqlite3'
   s.requires_arc = true
 


### PR DESCRIPTION
Users may want to build the AWS SDK with Clang modules disabled `-fno-modules` because they are using `ccache` which doesn't support `-fmodules`. When modules are disabled, auto-linking of framework modules is also disabled, so these dependencies need to be expressed explicitly.