### PR TITLE
Fix import for static library build to succeed

### DIFF
--- a/AWSS3/AWSS3RequestRetryHandler.m
+++ b/AWSS3/AWSS3RequestRetryHandler.m
@@ -14,7 +14,7 @@
 //
 
 #import "AWSS3RequestRetryHandler.h"
-#import "AWSService.h"
+#import <AWSCore/AWSService.h>
 
 @implementation AWSS3RequestRetryHandler
 


### PR DESCRIPTION
1. Install CocoaPods 1.5.0.
2. Replace `use_frameworks!` from your Podfile with `use_modular_headers!` to build as static libraries.
3. Build error will occur:
> /Users/Coeur/Development/Example/Pods/AWSS3/AWSS3/AWSS3RequestRetryHandler.m:41:42: Declaration of 'AWSServiceErrorDomain' must be imported from module 'AWSCore.AWSService' before it is required

This pull request makes AWSS3 compatible with both static libraries and frameworks.