### PR TITLE
Fix nullability warnings

### DIFF
--- a/AWSCore/Bolts/AWSTask.m
+++ b/AWSCore/Bolts/AWSTask.m
@@ -56,7 +56,7 @@ NSString *const AWSTaskMultipleErrorsUserInfoKey = @"errors";
     return self;
 }
 
-- (instancetype)initWithResult:(id)result {
+- (instancetype)initWithResult:(nullable id)result {
     self = [super init];
     if (!self) return self;
 

--- a/AWSCore/FMDB/AWSFMDatabase.m
+++ b/AWSCore/FMDB/AWSFMDatabase.m
@@ -338,7 +338,7 @@ static int AWSFMDBDatabaseBusyHandler(void *f, int count) {
 }
 
 
-- (void)setCachedStatement:(AWSFMStatement*)statement forQuery:(NSString*)query {
+- (void)setCachedStatement:(AWSFMStatement*)statement forQuery:(nonnull NSString*)query {
     
     query = [query copy]; // in case we got handed in a mutable string...
     [statement setQuery:query];
@@ -918,6 +918,10 @@ static int AWSFMDBDatabaseBusyHandler(void *f, int count) {
 #pragma mark Execute updates
 
 - (BOOL)executeUpdate:(NSString*)sql error:(NSError**)outErr withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args {
+    
+    if (!sql) {
+        return YES;
+    }
     
     if (![self databaseExists]) {
         return NO;

--- a/AWSLex/AWSLexInteractionKit.m
+++ b/AWSLex/AWSLexInteractionKit.m
@@ -285,7 +285,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
             interactionKitConfig = [AWSLexInteractionKitConfig defaultInteractionKitConfigWithBotName:botName botAlias:botAlias];
         }
         
-        if (!serviceConfiguration && !interactionKitConfig) {
+        if (!serviceConfiguration || !interactionKitConfig) {
             @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                            reason:@"The service configuration is `nil`. You need to configure `Info.plist` or set `defaultServiceConfiguration` before using this method."
                                          userInfo:nil];
@@ -315,8 +315,8 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
     [_serviceClients removeObjectForKey:key];
 }
 
-- (instancetype)initWithServiceConfiguration:(AWSServiceConfiguration *)serviceConfiguration
-                        interactionKitConfig:(AWSLexInteractionKitConfig *)interactionConfig
+- (instancetype)initWithServiceConfiguration:(nonnull AWSServiceConfiguration *)serviceConfiguration
+                        interactionKitConfig:(nonnull AWSLexInteractionKitConfig *)interactionConfig
 {
     if (self = [super init]) {
         _configuration = [serviceConfiguration copy];


### PR DESCRIPTION
AWSTask.m warning fix:
* `taskWithResult` accepts a nullable result, so `initWithResult` needs the same nullability specifier.

AWSFMDatabase.m warning fixes:
* `setCachedStatement:forQuery:` calls `setObject:forKey:`, so the query must be nonnull.
* `executeUpdate:error:withArgumentsInArray:orDictionary:` calls `setCachedStatement:forQuery:`, so the query must be tested for nil. We return `YES` because we successfully executed nothing and we didn't set `<lastError>`, `<lastErrorCode>`, or `<lastErrorMessage>` to anything.

AWSLexInteractionKit.m fix:
* AWSLexInteractionKit can't be initialized with nil values (because _interactionKitConfig requires to be non null and `registerLexWithConfiguration:forKey:` requires non null parameter)
