### PR TITLE
preventing corruption from failed malloc

### DIFF
--- a/AWSCognito/Internal/AWSCognitoUtil.m
+++ b/AWSCognito/Internal/AWSCognitoUtil.m
@@ -51,7 +51,15 @@
 + (NSString *)hexEncode:(NSString *)string
 {
     NSUInteger len    = [string length];
+    if (len == 0) {
+        return @"";
+    }
     unichar    *chars = malloc(len * sizeof(unichar));
+    if (chars == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
+        return nil;
+    }
 
     [string getCharacters:chars];
 

--- a/AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m
+++ b/AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityProviderSrpHelper.m
@@ -70,6 +70,11 @@ static NSString* N_IN_HEX = @"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129
     unsigned int maxNumBytes = [N countBytes] + 1;
 
     uint8_t *bytes = malloc(sizeof(uint8_t) * maxNumBytes);
+    if (bytes == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
+        return nil;
+    }
 
     CC_SHA256_CTX ctx;
     CC_SHA256_Init(&ctx);
@@ -212,6 +217,11 @@ static NSString* N_IN_HEX = @"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129
     size_t aBitLength = bitLength;
     size_t aByteLength = aBitLength/8;
     uint8_t *aBytes = malloc(aByteLength);
+    if (aBytes == NULL && aByteLength > 0) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
+        return nil;
+    }
     int functionExitCode = SecRandomCopyBytes(kSecRandomDefault, aByteLength, aBytes);
     if (functionExitCode < 0) {
         AWSDDLogError(@"SecRandomCopyBytes failed with error code %d: %s", errno, strerror(errno));

--- a/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m
+++ b/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m
@@ -43,6 +43,11 @@ AWSJKBigInteger *signedBigIntegerFromNSData(NSData* data) {
     AWSJKBigInteger *twosComplementMinusOneMaybe = nil;
     unsigned long bufferLength = data.length + 1;
     uint8_t *bytes = malloc(sizeof(uint8_t) * bufferLength);
+    if (bytes == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
+        return nil;
+    }
     
     memcpy(bytes+1, data.bytes, data.length);
     
@@ -71,9 +76,13 @@ AWSJKBigInteger *signedBigIntegerFromNSData(NSData* data) {
 @implementation NSData (NSDataBigInteger)
 + (NSData*) aws_dataWithBigInteger:(AWSJKBigInteger *)bigInteger {
     unsigned int byteCount = [bigInteger countBytes];
-    
+    if (byteCount == 0) {
+        return [NSData data];
+    }
     uint8_t *bytes = malloc(byteCount);
-    if (!bytes) {
+    if (bytes == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
         return nil;
     }
     
@@ -90,7 +99,9 @@ AWSJKBigInteger *signedBigIntegerFromNSData(NSData* data) {
     
     // +1 for sign byte
     uint8_t *bytes = malloc(byteCount + 1);
-    if (!bytes) {
+    if (bytes == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
         return nil;
     }
     
@@ -139,7 +150,15 @@ AWSJKBigInteger *signedBigIntegerFromNSData(NSData* data) {
     }
     
     NSUInteger outputLen = len / 2;
+    if (outputLen == 0) {
+        return [NSData data];
+    }
     uint8_t *output = malloc(sizeof(uint8_t) * outputLen);
+    if (output == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
+        return nil;
+    }
     
     const char *hexBytes = (const char*)[hexStrData bytes];
     for (NSUInteger i = 0, j=0; i < len && j < outputLen; i += 2, j++) {

--- a/AWSCore/Authentication/AWSSignature.m
+++ b/AWSCore/Authentication/AWSSignature.m
@@ -61,7 +61,15 @@ NSString *const AWSSignatureV4Terminator = @"aws4_request";
 
 + (NSString *)hexEncode:(NSString *)string {
     NSUInteger len = [string length];
+    if (len == 0) {
+        return @"";
+    }
     unichar *chars = malloc(len * sizeof(unichar));
+    if (chars == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
+        return nil;
+    }
 
     [string getCharacters:chars];
 


### PR DESCRIPTION
This change is to enforce a better security practice: when you can't malloc something you must handle the situation in some way to:
* avoid generating non-random numbers
* avoid generating corrupted data

This is a legitimate situation where you want to crash early.