### PR TITLE
method is expected to return a non-null value

### DIFF
--- a/AWSDynamoDB/AWSDynamoDBObjectMapper.m
+++ b/AWSDynamoDB/AWSDynamoDBObjectMapper.m
@@ -374,7 +374,7 @@ completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandl
         default:
             break;
     }
-    return nil;
+    return [AWSTask taskWithError:[NSError errorWithDomain:AWSDynamoDBErrorDomain code:AWSDynamoDBErrorUnknown userInfo:nil]];
 }
 
 - (void)save:(AWSDynamoDBObjectModel<AWSDynamoDBModeling> *)model


### PR DESCRIPTION
This return will only occur on `AWSDynamoDBObjectMapperSaveBehaviorUnknown`. But `AWSTask` being a rip-off famous [`BFTask`](https://github.com/BoltsFramework/Bolts-ObjC), chaining is fundamental and `nil` must never be returned.