### PR TITLE
Ensure that only one instance of getSession runs at a time

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -150,7 +150,11 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 - (instancetype)initWithConfiguration:(AWSCognitoAuthConfiguration *)authConfiguration; {
     if (self = [super init]) {
         _signOutQueue = [NSOperationQueue new];
+        _signOutQueue.maxConcurrentOperationCount = 1;
+        
         _getSessionQueue = [NSOperationQueue new];
+        _getSessionQueue.maxConcurrentOperationCount = 1;
+        
         _authConfiguration = [authConfiguration copy];
         _keychain = [AWSCognitoAuthUICKeyChainStore keyChainStoreWithService:[NSString stringWithFormat:@"%@.%@", [NSBundle mainBundle].bundleIdentifier, @"AWSCognitoIdentityUserPool"]];  //Consistent with AWSCognitoIdentityUserPool
     }


### PR DESCRIPTION
Calls to getSession are not thread safe. Specifically they share
getSessionBlock which can cause the same completion block to be
called multiple times.

This change ensures that only once call to getSession runs at a time.