### PR TITLE
Fixes 2 incorrect clang pragmas

### DIFF
--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
@@ -528,7 +528,7 @@ static NSString *_defaultService;
     query[(__bridge __strong id)kSecAttrAccount] = key;
 #if TARGET_OS_IOS
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wunguarded-availability"
     if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
         query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
     } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+

--- a/AWSCore/Utility/AWSLogging.m
+++ b/AWSCore/Utility/AWSLogging.m
@@ -17,7 +17,7 @@
 #import "AWSService.h"
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 
 @implementation AWSLogger
 


### PR DESCRIPTION
I believe theses pragmas were meant to suppress the warnings being generated but instead disabled warning generation for diagnostics that weren't actually producing warnings. This updates fixes the warnings produced when using AWSCore with cocoapods.