### PR TITLE
Convenience function to force new auth tokens.

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -107,6 +107,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (AWSTask<AWSCognitoIdentityUserSession *> *)getSession;
 
 /**
+ Get a session with id, access and refresh tokens. Force the refreshing of authentication tokens by passing in the `forceRefresh` flag.
+ */
+-(AWSTask<AWSCognitoIdentityUserSession*> *) getSessionAndForceTokenRefresh: (BOOL)forceRefresh;
+
+/**
  Get a session with the following username and password
  */
 - (AWSTask<AWSCognitoIdentityUserSession *> *)getSession:(NSString *)username

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -159,7 +159,13 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
  Get a session
  */
 -(AWSTask<AWSCognitoIdentityUserSession*> *) getSession {
-    
+    return [self getSessionAndForceTokenRefresh:false];
+}
+
+/**
+ Get a session, force the refreshing of authentication tokens by passing in the `forceRefresh` flag.
+ */
+-(AWSTask<AWSCognitoIdentityUserSession*> *) getSessionAndForceTokenRefresh: (BOOL)forceRefresh {
     //check to see if we have valid tokens
     __block NSString * keyChainNamespace = [self keyChainNamespaceClientId];
     NSString * expirationTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserTokenExpiration];
@@ -174,7 +180,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
         self.confirmedStatus = AWSCognitoIdentityUserStatusConfirmed;
 
         //if the session expires > 5 minutes return it.
-        if(expiration && [expiration compare:[NSDate dateWithTimeIntervalSinceNow:5 * 60]] == NSOrderedDescending){
+        if(expiration && [expiration compare:[NSDate dateWithTimeIntervalSinceNow:5 * 60]] == NSOrderedDescending && !forceRefresh){
             NSString * idTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserIdToken];
             NSString * accessTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserAccessToken];
             AWSCognitoIdentityUserSession * session = [[AWSCognitoIdentityUserSession alloc] initWithIdToken:self.pool.keychain[idTokenKey] accessToken:self.pool.keychain[accessTokenKey] refreshToken:refreshToken expirationTime:expiration];


### PR DESCRIPTION
**Why?**
We are building an iOS app that allows a user to gain more access by making a purchase. We have architected this using Cognito User Pools. 
When a user signs up and makes a purchase we transfer them from one group top another. But in order to gain access to the endpoints we need to refresh the auth tokens. Fetching and refreshing the tokens are done calling: `getSession` in `AWSCognitoIdentityUser`.
There is logic in `getSession` that will only allow for the tokens to be refreshed if they have expired or are about to expire.

**What?**
I've added another function that will allow for forcing the refresh of the auth tokens even if they are valid.
