### PR TITLE
Prevent to re-send previous session stop event when app launched

### DIFF
--- a/AWSPinpoint/AWSPinpointSessionClient.m
+++ b/AWSPinpoint/AWSPinpointSessionClient.m
@@ -179,7 +179,7 @@ typedef void(^voidBlock)(void);
             AWSDDLogError(@"Pinpoint Analytics is disabled.");
             return nil;
         }
-        if (_session) {
+        if (_session && ![_session stopTime]) {
             [self endCurrentSession];
             return [self startNewSession];
         } else {


### PR DESCRIPTION
* What service are you using? > Pinpoint
* In what version of SDK are you facing the problem? > 2.6.19
* Is the issue limited to Simulators / Actual Devices? > Both
* Is this problem related to specific iOS version? > No
* How are you consuming the SDK? CocoaPods / Carthage / Prebuilt frameworks? > Carthage

## Summary
App send the stop event of the previous session when it restarted.

## Steps to reproduce
The configuration is default.
```
let configuration = AWSPinpointConfiguration.defaultPinpointConfiguration(launchOptions: launchOptions)
pinpoint = AWSPinpoint(configuration: configuration)
```

1. Launch
1. Do some actions
1. Go background by iPhone home button pushed
1. Kill app process and restart

In Step 4, the `stop` event of the previous session (id: xxx-034136953) and the current session (id: yyy-034220647) `start` event are sent.
Since the `stop` event of the previous session has already been sent in Step 3, it duplicates.

### Post data
1. Launch & 2. Do some actions
```
{"events":[{"timestamp":"2018-05-30T03:41:36.954Z","session":{"id":"xxx-034136953","duration":136,"startTimestamp":"2018-05-30T03:41:36.954Z"},"metrics":{},"eventType":"_session.start","attributes":{}},{"timestamp":"2018-05-30T03:41:37.078Z","session":{"id":"xxx-034136953","duration":136,"startTimestamp":"2018-05-30T03:41:36.954Z"},"metrics":{},"eventType":"screen_view","attributes":{"screen_name":"foo"}}]}
```

3. Push home button (pause, and after 5 second stop)
```
{"events":[{"timestamp":"2018-05-30T03:41:43.368Z","session":{"duration":6405,"stopTimestamp":"2018-05-30T03:41:43.359Z","id":"xxx-034136953","startTimestamp":"2018-05-30T03:41:36.954Z"},"metrics":{},"eventType":"_session.pause","attributes":{"foo":"bar"}},{"timestamp":"2018-05-30T03:41:48.429Z","session":{"duration":6405,"stopTimestamp":"2018-05-30T03:41:43.359Z","id":"xxx-034136953","startTimestamp":"2018-05-30T03:41:36.954Z"},"metrics":{},"eventType":"_session.stop","attributes":{"foo":"bar"}}]}
```

4. Restart
```
{"events":[{"timestamp":"2018-05-30T03:42:20.644Z","session":{"duration":6405,"stopTimestamp":"2018-05-30T03:41:43.359Z","id":"xxx-034136953","startTimestamp":"2018-05-30T03:41:36.954Z"},"metrics":{},"eventType":"_session.stop","attributes":{}},{"timestamp":"2018-05-30T03:42:20.647Z","session":{"id":"yyy-034220647","duration":133,"startTimestamp":"2018-05-30T03:42:20.647Z"},"metrics":{},"eventType":"_session.start","attributes":{}},{"timestamp":"2018-05-30T03:42:20.769Z","session":{"id":"yyy-034220647","duration":133,"startTimestamp":"2018-05-30T03:42:20.647Z"},"metrics":{},"eventType":"screen_view","attributes":{"screen_name":"foo"}}]}
```

## Cause
When initializing AWSPinpointSessionClient object by initWithContext, also unarchiving previous session object from the user defaults.
And, if a session exists, the previous session is stopped and a new session is started in startSession function.
https://github.com/aws/aws-sdk-ios/blob/master/AWSPinpoint/AWSPinpointSessionClient.m#L98
https://github.com/aws/aws-sdk-ios/blob/master/AWSPinpoint/AWSPinpointSessionClient.m#L182

## Fix
If the current session is already stopped, no stop event will be sent 