### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ CocoaLumberjack logging levels are additive such that when the level is set to v
 **Swift**
 
 ```swift
-AWSDDLog.sharedInstance().logLevel = .verbose
+AWSDDLog.sharedInstance.logLevel = .verbose
 ```
 
 The following logging level options are available:


### PR DESCRIPTION
In swift 4, having the () in shared instance throws error - Cannot call value of non-function type 'AWSDDLog'. Removing the () fixes that.