### PR TITLE
Added a AWSCognitoAuthSessionDidSaveNotification notification.

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  </ul>
  */
 FOUNDATION_EXPORT NSString *const AWSCognitoAuthErrorDomain;
+FOUNDATION_EXPORT NSString *const AWSCognitoAuthSessionDidSaveNotification;
 
 typedef NS_ENUM(NSInteger, AWSCognitoAuthClientErrorType) {
     AWSCognitoAuthClientErrorUnknown = 0,

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -20,6 +20,7 @@
 #import <CommonCrypto/CommonHMAC.h>
 
 NSString *const AWSCognitoAuthErrorDomain = @"com.amazon.cognito.AWSCognitoAuthErrorDomain";
+NSString *const AWSCognitoAuthSessionDidSaveNotification = @"com.amazon.cognito.AWSCognitoAuthSessionDidSaveNotification";
 
 @interface AWSCognitoAuth()<SFSafariViewControllerDelegate, NSURLConnectionDelegate>
 
@@ -626,6 +627,11 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         }else{
             [self updateUsernameAndPersistTokens:userSession];
             [self completeGetSession:userSession error:nil];
+            
+            [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+                NSNotification *notification = [NSNotification notificationWithName:AWSCognitoAuthSessionDidSaveNotification object:userSession];
+                [[NSNotificationCenter defaultCenter] postNotification:notification];
+            }];
         }
     }
 }


### PR DESCRIPTION
A facade API can abstract the AWSCognitoAuth and login with email and could be notified when the session is refreshed to not have stale cached data.