### PR TITLE
Feature/add sign in uri parameter

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -205,7 +205,6 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  @param scopes Set of scopes to obtain
  @param signInRedirectUri uri to redirect on sign in.  Must be configured as a uri scheme in your info.plist
  @param signOutRedirectUri uri to redirect on sign out.  Must be configured as a uri scheme in your info.plist
- @param signInUri uri on sign in.  Must be configured as a uri scheme in your info.plist
  @param webDomain The FQDN of your Cognito endpoint, something like https://mydomain.region.auth.amazoncognito.com
  */
 - (instancetype)initWithAppClientId:(NSString *) appClientId
@@ -213,8 +212,29 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
-                          signInUri:(NSString *) signInUri
                           webDomain:(NSString *) webDomain;
+
+/**
+ Configuration object for CognitoAuth
+ @param appClientId The app client id
+ @param appClientSecret The optional app client secret
+ @param scopes Set of scopes to obtain
+ @param signInRedirectUri uri to redirect on sign in.  Must be configured as a uri scheme in your info.plist
+ @param signOutRedirectUri uri to redirect on sign out.  Must be configured as a uri scheme in your info.plist
+ @param webDomain The FQDN of your Cognito endpoint, something like https://mydomain.region.auth.amazoncognito.com
+ @param identityProvider Optional provider name to authenticate with directly
+ @param idpIdentifier Optional provider identifier to authenticate with directly
+ @param userPoolIdForEnablingASF Optional user pool id for enabling advanced security features
+ */
+- (instancetype)initWithAppClientId:(NSString *) appClientId
+                    appClientSecret:(nullable NSString *) appClientSecret
+                             scopes:(NSSet<NSString *> *) scopes
+                  signInRedirectUri:(NSString *) signInRedirectUri
+                 signOutRedirectUri:(NSString *) signOutRedirectUri
+                          webDomain:(NSString *) webDomain
+                   identityProvider:(nullable NSString *) identityProvider
+                      idpIdentifier:(nullable NSString *) idpIdentifier
+                         userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF;
 
 /**
  Configuration object for CognitoAuth
@@ -234,11 +254,11 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
-                          signInUri:(NSString *) signInUri
+                          signInUri:(nullable NSString *) signInUri
                           webDomain:(NSString *) webDomain
                    identityProvider:(nullable NSString *) identityProvider
                       idpIdentifier:(nullable NSString *) idpIdentifier
-                         userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF;
+           userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF;
 @end
 
 

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -168,6 +168,11 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
 @property (nonatomic, readonly) NSString * signOutRedirectUri;
 
 /**
+ uri on sign in.  Must be configured as a uri scheme in your info.plist
+ */
+@property (nonatomic, readonly) NSString * signInUri;
+
+/**
  The FQDN of your Cognito endpoint, something like https://mydomain.region.auth.amazoncognito.com
  */
 @property (nonatomic, readonly) NSString * webDomain;
@@ -200,6 +205,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  @param scopes Set of scopes to obtain
  @param signInRedirectUri uri to redirect on sign in.  Must be configured as a uri scheme in your info.plist
  @param signOutRedirectUri uri to redirect on sign out.  Must be configured as a uri scheme in your info.plist
+ @param signInUri uri on sign in.  Must be configured as a uri scheme in your info.plist
  @param webDomain The FQDN of your Cognito endpoint, something like https://mydomain.region.auth.amazoncognito.com
  */
 - (instancetype)initWithAppClientId:(NSString *) appClientId
@@ -207,6 +213,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
+                          signInUri:(NSString *) signInUri
                           webDomain:(NSString *) webDomain;
 
 /**
@@ -216,6 +223,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  @param scopes Set of scopes to obtain
  @param signInRedirectUri uri to redirect on sign in.  Must be configured as a uri scheme in your info.plist
  @param signOutRedirectUri uri to redirect on sign out.  Must be configured as a uri scheme in your info.plist
+ @param signInUri uri on sign in.  Must be configured as a uri scheme in your info.plist
  @param webDomain The FQDN of your Cognito endpoint, something like https://mydomain.region.auth.amazoncognito.com
  @param identityProvider Optional provider name to authenticate with directly
  @param idpIdentifier Optional provider identifier to authenticate with directly
@@ -226,6 +234,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
+                          signInUri:(NSString *) signInUri
                           webDomain:(NSString *) webDomain
                    identityProvider:(nullable NSString *) identityProvider
                       idpIdentifier:(nullable NSString *) idpIdentifier

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -67,6 +67,7 @@ static NSString *const AWSCognitoAuthWebDomain = @"WebDomain";
 static NSString *const AWSCognitoAuthScopes = @"Scopes";
 static NSString *const AWSCognitoAuthSignInRedirectUri = @"SignInRedirectUri";
 static NSString *const AWSCognitoAuthSignOutRedirectUri = @"SignOutRedirectUri";
+static NSString *const AWSCognitoAuthSignInUri = @"CognitoAuthSignInUri";
 static NSString *const AWSCognitoAuthIdpIdentifier = @"IdpIdentifier";
 static NSString *const AWSCognitoAuthIdentityProvider = @"IdentityProvider";
 static NSString *const AWSCognitoAuthPoolId = @"PoolIdForEnablingASF";
@@ -94,6 +95,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         NSSet<NSString *> *scopes = scopesSet;
         NSString *signInRedirectUri = infoDictionary[AWSCognitoAuthSignInRedirectUri] ?: infoDictionary[AWSCognitoAuthSignInRedirectUriLegacy];
         NSString *signOutRedirectUri = infoDictionary[AWSCognitoAuthSignOutRedirectUri] ?: infoDictionary[AWSCognitoAuthSignOutRedirectUriLegacy];
+        NSString *signInUri = infoDictionary[AWSCognitoAuthSignInUri];
         NSString *idpIdentifier = infoDictionary[AWSCognitoAuthIdpIdentifier];
         NSString *identityProvider = infoDictionary[AWSCognitoAuthIdentityProvider];
         NSString *userPoolId = infoDictionary[AWSCognitoAuthPoolId];
@@ -104,6 +106,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                                                                                                                scopes:scopes
                                                                                                     signInRedirectUri:signInRedirectUri
                                                                                                    signOutRedirectUri:signOutRedirectUri
+                                                                                                            signInUri:signInUri
                                                                                                             webDomain:webDomain
                                                                                                      identityProvider:identityProvider
                                                                                                         idpIdentifier:idpIdentifier
@@ -222,7 +225,12 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         suffix = [suffix stringByAppendingString:userContext];
     }
     
-    NSString *url = [NSString stringWithFormat:@"%@/oauth2/authorize?response_type=code&client_id=%@&state=%@&redirect_uri=%@&scope=%@&code_challenge=%@&code_challenge_method=S256%@",self.authConfiguration.webDomain, self.authConfiguration.appClientId, self.state,[self urlEncode:self.authConfiguration.signInRedirectUri], [self urlEncode:[self normalizeScopes]], self.proofKeyHash, suffix];
+    NSString *url = @"";
+    if(self.authConfiguration.signInUri){
+        url = [NSString stringWithFormat:@"%@?response_type=code&client_id=%@&state=%@&redirect_uri=%@&scope=%@&code_challenge=%@&code_challenge_method=S256%@", self.authConfiguration.signInUri, self.authConfiguration.appClientId, self.state,[self urlEncode:self.authConfiguration.signInRedirectUri], [self urlEncode:[self normalizeScopes]], self.proofKeyHash, suffix];
+    } else {
+        url = [NSString stringWithFormat:@"%@/oauth2/authorize?response_type=code&client_id=%@&state=%@&redirect_uri=%@&scope=%@&code_challenge=%@&code_challenge_method=S256%@",self.authConfiguration.webDomain, self.authConfiguration.appClientId, self.state,[self urlEncode:self.authConfiguration.signInRedirectUri], [self urlEncode:[self normalizeScopes]], self.proofKeyHash, suffix];
+    }
     self.svc = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:url] entersReaderIfAvailable:NO];
     self.svc.delegate = self;
     self.svc.modalPresentationStyle = UIModalPresentationPopover;
@@ -880,9 +888,10 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
+                          signInUri:(NSString *) signInUri
                           webDomain:(NSString *) webDomain
 {
-    return [self initWithAppClientId:appClientId appClientSecret:appClientSecret scopes:scopes signInRedirectUri:signInRedirectUri signOutRedirectUri:signOutRedirectUri webDomain:webDomain identityProvider:nil idpIdentifier:nil userPoolIdForEnablingASF:nil];
+    return [self initWithAppClientId:appClientId appClientSecret:appClientSecret scopes:scopes signInRedirectUri:signInRedirectUri signOutRedirectUri:signOutRedirectUri signInUri:signInUri webDomain:webDomain identityProvider:nil idpIdentifier:nil userPoolIdForEnablingASF:nil];
 }
 
 - (instancetype)initWithAppClientId:(NSString *) appClientId
@@ -890,6 +899,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
+                          signInUri:(NSString *) signInUri
                           webDomain:(NSString *) webDomain
                    identityProvider:(nullable NSString *) identityProvider
                       idpIdentifier:(nullable NSString *) idpIdentifier
@@ -901,6 +911,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         _scopes = scopes;
         _signInRedirectUri = signInRedirectUri;
         _signOutRedirectUri = signOutRedirectUri;
+        _signInUri = signInUri;
         _webDomain = webDomain;
         _identityProvider = identityProvider;
         _idpIdentifier = idpIdentifier;
@@ -917,6 +928,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                                                                                                  scopes:self.scopes
                                                                                       signInRedirectUri:self.signInRedirectUri
                                                                                      signOutRedirectUri:self.signOutRedirectUri
+                                                                                              signInUri:self.signInUri
                                                                                               webDomain:self.webDomain
                                                                                        identityProvider:self.identityProvider
                                                                                           idpIdentifier:self.idpIdentifier

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -888,10 +888,9 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
-                          signInUri:(NSString *) signInUri
                           webDomain:(NSString *) webDomain
 {
-    return [self initWithAppClientId:appClientId appClientSecret:appClientSecret scopes:scopes signInRedirectUri:signInRedirectUri signOutRedirectUri:signOutRedirectUri signInUri:signInUri webDomain:webDomain identityProvider:nil idpIdentifier:nil userPoolIdForEnablingASF:nil];
+    return [self initWithAppClientId:appClientId appClientSecret:appClientSecret scopes:scopes signInRedirectUri:signInRedirectUri signOutRedirectUri:signOutRedirectUri signInUri:nil webDomain:webDomain identityProvider:nil idpIdentifier:nil userPoolIdForEnablingASF:nil];
 }
 
 - (instancetype)initWithAppClientId:(NSString *) appClientId
@@ -899,11 +898,24 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                              scopes:(NSSet<NSString *> *) scopes
                   signInRedirectUri:(NSString *) signInRedirectUri
                  signOutRedirectUri:(NSString *) signOutRedirectUri
-                          signInUri:(NSString *) signInUri
                           webDomain:(NSString *) webDomain
                    identityProvider:(nullable NSString *) identityProvider
                       idpIdentifier:(nullable NSString *) idpIdentifier
                          userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF;
+{
+    return [self initWithAppClientId:appClientId appClientSecret:appClientSecret scopes:scopes signInRedirectUri:signInRedirectUri signOutRedirectUri:signOutRedirectUri signInUri:nil webDomain:webDomain identityProvider:identityProvider idpIdentifier:idpIdentifier userPoolIdForEnablingASF:userPoolIdForEnablingASF];
+}
+
+- (instancetype)initWithAppClientId:(NSString *) appClientId
+                    appClientSecret:(nullable NSString *)appClientSecret
+                             scopes:(NSSet<NSString *> *) scopes
+                  signInRedirectUri:(NSString *) signInRedirectUri
+                 signOutRedirectUri:(NSString *) signOutRedirectUri
+                          signInUri:(nullable NSString *) signInUri
+                          webDomain:(NSString *) webDomain
+                   identityProvider:(nullable NSString *) identityProvider
+                      idpIdentifier:(nullable NSString *) idpIdentifier
+           userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF
 {
     if (self = [super init]) {
         _appClientId = appClientId;


### PR DESCRIPTION
Thank you for providing a great SDK.
The purpose of this change is to make Cognito's authentication page customizable.
In the current source code, the URL of the authentication page is generated based on the parameter "CognitoAuthWebDomain" in the plist file.
I would like to create an authentication page in a domain different from "CognitoAuthWebDomain" and display it in the in-app browser. For that purpose, we added a new parameter "CognitoAuthSignInUri" to the plist file. By setting the URL of the authentication page to this parameter, the custom authentication page is displayed.
Since I need this change, I would appreciate it if you merge the pull request. Thank you for your consideration.