### PR TITLE
AWSIoTMQTTClient: fix connection age timer not scheduled

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -811,12 +811,11 @@ static const NSString *SDK_VERSION = @"2.6.19";
             if (self.connectionAgeTimer != nil) {
                 [self.connectionAgeTimer invalidate];
             }
-            self.connectionAgeTimer = [[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSinceNow:1.0]
-                                     interval:1.0
-                                       target:self
-                                     selector:@selector(connectionAgeTimerHandler:)
-                                     userInfo:nil
-                                      repeats:YES];
+            self.connectionAgeTimer = [NSTimer scheduledTimerWithTimeInterval:1.0
+                                                                       target:self
+                                                                     selector:@selector(connectionAgeTimerHandler:)
+                                                                     userInfo:nil
+                                                                      repeats:YES];
 
             //Subscribe to prior topics
             if (_autoResubscribe) {


### PR DESCRIPTION
Currently, the `connectionAgeTimer` in `AWSIoTMQTTClient` gets initialized, but never scheduled. This results in the exponential backoff timer increasing for each disconnect and never being reset to the base reconnect time.