### PR TITLE
Optional method added to the AWSCognitoAuthDelegate protocol and the AWSCognitoAuthClientErrorExpiredRefreshToken error case.

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  <li>AWSCognitoAuthClientErrorSecurityReason - The security of this request could not be guaranteed.</li>
  <li>AWSCognitoAuthClientInvalidAuthenticationDelegate - The AWSCognitoAuthDelegate delegate is not setup or returned an invalid value.</li>
  <li>AWSCognitoAuthClientNoIdTokenIssued - If no id token was issued. For future use. </li>
+ <li>AWSCognitoAuthClientErrorExpiredRefreshToken - If the refresh token is expired. </li>
  </ul>
  */
 FOUNDATION_EXPORT NSString *const AWSCognitoAuthErrorDomain;
@@ -45,7 +46,8 @@ typedef NS_ENUM(NSInteger, AWSCognitoAuthClientErrorType) {
     AWSCognitoAuthClientErrorBadRequest = -3000,
     AWSCognitoAuthClientErrorSecurityFailed = -4000,
     AWSCognitoAuthClientInvalidAuthenticationDelegate = -5000,
-    AWSCognitoAuthClientNoIdTokenIssued = -6000
+    AWSCognitoAuthClientNoIdTokenIssued = -6000,
+    AWSCognitoAuthClientErrorExpiredRefreshToken = -7000
 };
 
 typedef void (^AWSCognitoAuthGetSessionBlock)(AWSCognitoAuthUserSession * _Nullable session, NSError * _Nullable error);

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -291,6 +291,12 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  Get view controller to display user authentication on top of.
  */
 - (UIViewController *) getViewController;
+
+@optional
+/**
+ If refresh token is expired, let the user decide if the signInVC should be presented or an error should be returned.
+ */
+- (BOOL) shouldLaunchSignInVCIfRefreshTokenIsExpired;
 @end
 
 

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -614,8 +614,16 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
     else if(result[@"error"]){
         //refresh token has expired, switch to interactive auth
         if([@"invalid_grant" isEqualToString:result[@"error"]]){
-            [self launchSignInVC:self.pvc];
-            return;
+            if (![self.delegate respondsToSelector:@selector(shouldLaunchSignInVCIfRefreshTokenIsExpired)]) {
+                [self launchSignInVC:self.pvc];
+                return;
+            }else {
+                BOOL present = [self.delegate shouldLaunchSignInVCIfRefreshTokenIsExpired];
+                if (present) {
+                    [self launchSignInVC:self.pvc];
+                    return;
+                }
+            }
         }
         
         [self completeGetSession:nil error:[self getError:result[@"error"] code:AWSCognitoAuthClientErrorUnknown]];

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -616,17 +616,17 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         if([@"invalid_grant" isEqualToString:result[@"error"]]){
             if (![self.delegate respondsToSelector:@selector(shouldLaunchSignInVCIfRefreshTokenIsExpired)]) {
                 [self launchSignInVC:self.pvc];
-                return;
             }else {
                 BOOL present = [self.delegate shouldLaunchSignInVCIfRefreshTokenIsExpired];
                 if (present) {
                     [self launchSignInVC:self.pvc];
-                    return;
+                }else {
+                    [self completeGetSession:nil error:[self getError:result[@"error"] code:AWSCognitoAuthClientErrorExpiredRefreshToken]];
                 }
             }
+        }else {
+            [self completeGetSession:nil error:[self getError:result[@"error"] code:AWSCognitoAuthClientErrorUnknown]];
         }
-        
-        [self completeGetSession:nil error:[self getError:result[@"error"] code:AWSCognitoAuthClientErrorUnknown]];
     }else {
         AWSCognitoAuthUserSession *userSession = [[AWSCognitoAuthUserSession alloc] initWithIdToken:[result valueForKey:@"id_token"]  accessToken:[result valueForKey:@"access_token"] refreshToken:[result valueForKey:@"refresh_token"] expiresIn:[result valueForKey:@"expires_in"]];
         if(!userSession.accessToken){


### PR DESCRIPTION
…AuthDelegate. It will let the user decide if `launchSignInVC` is called when the refresh token is expired or not.