### PR TITLE
Expose the `signOutLocallyAndClearLastKnownUser` method for Cognito.

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -126,6 +126,10 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  */
 - (void) signOut: (nullable AWSCognitoAuthSignOutBlock) completion;
 
+/**
+ Remove user session from keychain and clear last known username.
+ */
+-(void) signOutLocallyAndClearLastKnownUser;
 
 /**
  Method to handle app redirect.  Call from AppDelegate application:openURL:options


### PR DESCRIPTION
Add a public method for signing out and clearing the last known user.